### PR TITLE
#R9BED1 R9 cancel pending trade

### DIFF
--- a/src/main/java/bton/ci536/fizzit/trade/Trade.java
+++ b/src/main/java/bton/ci536/fizzit/trade/Trade.java
@@ -104,6 +104,10 @@ public class Trade implements Serializable, Comparable<Trade>{
         tradeStatuses.add(ts);
     }
     
+    public void cancelTrade() {
+        tradeStatuses.add(new TradeStatus(this, TradeStatus.CANCELLED));
+    }
+    
     public double getTotalValue() {
         return tradeItems
                 .stream()

--- a/src/main/java/bton/ci536/fizzit/trade/TradeRepository.java
+++ b/src/main/java/bton/ci536/fizzit/trade/TradeRepository.java
@@ -48,7 +48,6 @@ public class TradeRepository {
         
         try {
             ut.begin();
-            trade.nextStatus();
             em.merge(trade);
             ut.commit();
         } catch(Exception ex) {

--- a/src/main/java/bton/ci536/fizzit/trade/TradeStatus.java
+++ b/src/main/java/bton/ci536/fizzit/trade/TradeStatus.java
@@ -22,6 +22,7 @@ public class TradeStatus implements Serializable, Comparable<TradeStatus>{
     public final static int IN_TRANSIT_TO_WAREHOUSE = 1;
     public final static int CHECKING_AT_WAREHOUSE = 2;
     public final static int COMPLETED = 3;
+    public final static int CANCELLED = 4;
     
     @Id
     @Column(name = "status")
@@ -43,6 +44,11 @@ public class TradeStatus implements Serializable, Comparable<TradeStatus>{
     public TradeStatus(Trade trade) {
         this();
         this.trade = trade;
+    }
+    
+    public TradeStatus(Trade trade, int status) {
+        this(trade);
+        this.status = status;
     }
 
     public int getStatus() {
@@ -79,6 +85,8 @@ public class TradeStatus implements Serializable, Comparable<TradeStatus>{
                 return "Checking at Warehouse";
             case COMPLETED: 
                 return "Completed";
+            case CANCELLED: 
+                return "Cancelled";
         }
         return "unknown";
     }

--- a/src/main/java/bton/ci536/fizzit/trade/TradeStatus.java
+++ b/src/main/java/bton/ci536/fizzit/trade/TradeStatus.java
@@ -92,7 +92,7 @@ public class TradeStatus implements Serializable, Comparable<TradeStatus>{
     }
     
     public TradeStatus next() {
-        if(status == COMPLETED)
+        if(status < COMPLETED)
             return this;
         TradeStatus next = new TradeStatus(trade);
         next.status = this.status+1;

--- a/src/main/webapp/admin/trades/all.xhtml
+++ b/src/main/webapp/admin/trades/all.xhtml
@@ -25,11 +25,12 @@
                     <h:outputText value="#{ctrade.totalValue}">
                         <f:convertNumber type="currency"/>
                     </h:outputText>
-                    <c:if test="#{ctrade.latestStatus.status != 3}">
-                        <h:form>
-                            <h:commandLink action="#{tradeRepository.update(ctrade)}">Progress</h:commandLink>
-                        </h:form>
-                    </c:if>
+                    <h:form rendered="#{ctrade.latestStatus.status != 3}">
+                        <h:commandLink value="Progress">
+                            <f:actionListener binding="#{ctrade.nextStatus()}"/>
+                            <f:actionListener binding="#{tradeRepository.update(ctrade)}"/>
+                        </h:commandLink>
+                    </h:form>
                     
                 </header>
                 <h:dataTable value="#{ctrade.tradeItems}"

--- a/src/main/webapp/trades.xhtml
+++ b/src/main/webapp/trades.xhtml
@@ -28,7 +28,7 @@
         <comp:menu/>
         
         <ui:repeat value="#{tradeRepository.getByCustomer(customer)}" var="ctrade">
-            <div class="trade-container">
+            <h:panelGroup rendered="true" layout="block" class="trade-container">
                 <header>
                     <span>Trade Id: #{ctrade.tradeId}</span>
                     <span>#{ctrade.latestStatus.statusString}</span>
@@ -36,7 +36,12 @@
                     <h:outputText value="#{ctrade.totalValue}">
                         <f:convertNumber type="currency"/>
                     </h:outputText>
-                    
+                    <h:form rendered="#{ctrade.latestStatus.status == 0}">
+                        <h:commandLink value="Cancel">
+                            <f:actionListener binding="#{ctrade.cancelTrade()}"/>
+                            <f:actionListener binding="#{tradeRepository.update(ctrade)}"/>
+                        </h:commandLink>
+                    </h:form>
                 </header>
                 <h:dataTable value="#{ctrade.tradeItems}"
                              var="item"
@@ -59,7 +64,7 @@
                     </h:column>
                 </h:dataTable>
                 
-            </div>
+            </h:panelGroup>
         </ui:repeat>
     </body>
 </html>


### PR DESCRIPTION
Cancellation is a new status for the trade so that the user can still see the cancel trade on their trade feed. It was this or removing the whole trade from the database? 

Cancellation option is only shown before the trade is delivered as per the requirement. 

TradeRepository::update much more sensibly only updates the trade entity and manipulate state and thus the state changing action was moved. 
